### PR TITLE
Fix exception message on command not found.

### DIFF
--- a/android_export.py
+++ b/android_export.py
@@ -109,12 +109,15 @@ parser.add_option("--resdir",  action="store",  help="Resources directory")
 parser.add_option("--resname", action="store",  help="Resource name (when --source=page)")
 
 group = DensityGroup(parser, "Select which densities to export")
-group.add_density_option("ldpi", 67.5)
-group.add_density_option("mdpi", 90)
-group.add_density_option("hdpi", 135)
-group.add_density_option("xhdpi", 180)
-group.add_density_option("xxhdpi", 270)
-group.add_density_option("xxxhdpi", 360)
+# dpi obtained from http://developer.android.com/guide/practices/screens_support.html
+# 3:4:6:8 ratio see Table 1. Configuration qualifiers that allow you to provide special resources for different screen configurations.
+# and 1:1.5:2:3:4 ratios from developer.android.com/design/style/iconography.html
+group.add_density_option("ldpi", 120)
+group.add_density_option("mdpi", 160)
+group.add_density_option("hdpi", 240)
+group.add_density_option("xhdpi", 320)
+group.add_density_option("xxhdpi", 480)
+group.add_density_option("xxxhdpi", 640)
 parser.add_option_group(group)
 
 parser.add_option("--strip",  action="store",  type="boolstr", help="Use ImageMagick to reduce the image size")


### PR DESCRIPTION
Running the export extension without OptiPNG with default settings was barfing badly. This just fixes the system call with a try-catch clause that will allow the intended error message to be returned.

The dpi numbers used in the list seem arbitrary. This uses the dpi settings recommended by the android.com site.
